### PR TITLE
Improve exercises 1-3

### DIFF
--- a/exercises/ex1/README.md
+++ b/exercises/ex1/README.md
@@ -58,12 +58,18 @@ The architecture of the resulting app will look like this:
    ```
    Notice that the **Pods** are not working correctly. This is because of
    security restrictions in OpenShift that enable it to be a multi-tenant cloud
-   platform.
+   platform. You can get more information about why a **Pod** is not working
+   correctly with the `oc logs` command:
+   ```bash
+   oc logs <name of a pod>
+   ```
 
 5. You will need to replace the NGINX image with one that is compatible with
-   OpenShift. You can use either `oc edit` or `oc replace -f` to achieve this.
-   If you have access to Docker, you can get a Dockerfile by the NGINX folk
-   here:
+   OpenShift. You can use either `oc edit <deployment name>` or
+   `oc replace -f <modified deployment yaml>` to achieve this.
+   Modify the **Deployment** you created in an earlier step to change the image.
+   You can list your **Deployments** with `oc get deployments`. If you have
+   access to Docker, you can get a Dockerfile by the NGINX folk here:
    [nginxinc/openshift-nginx](https://github.com/nginxinc/openshift-nginx).
    If you don't have access to Docker, you can also get the image at
    `docker-registry.rahti-int.csc.fi/oso-course/openshift-nginx`. Note that this
@@ -71,14 +77,16 @@ The architecture of the resulting app will look like this:
    OpenShift, but it's good to be aware that some images do require some
    changes.
 
-6. Inspect the status of the **Pods** once more. They should now be running.
+6. Inspect the status of the **Pods** once more. They should end up in the
+   "Running" state after a small wait.
 
 7. The default NGINX image uses port 80 by default, but the one for OpenShift
-   uses 8080 instead, so you will need to change the port exposed by the pods in
-   the **Deployment** and the **targetPort** setting in the **Service**. Note
-   that **Services** are immutable, so you cannot use `oc edit` or
-   `oc replace -f`. You need to use `oc replace --force -f` when you update the
-   **Service**. This deletes and recreates the **Service**.
+   uses 8080 instead, so you will need to change the port exposed by the
+   **Pods** in the **Deployment**. The *targetPort* setting in the **Service**
+   references the port in the **Pods** by name, so it does not need to be
+   updated. If you ever do need to modify a **Service**, note that they are
+   immutable, so you cannot use `oc edit` or `oc replace -f`. You need to use
+   `oc replace --force -f`. This deletes and recreates the **Service**.
 
 8. If all went well, you should now be able to access NGINX. Check the address
     from the **Route** you created in an earlier step:

--- a/exercises/ex1/nginx-deployment.yaml
+++ b/exercises/ex1/nginx-deployment.yaml
@@ -14,4 +14,5 @@ spec:
       - name: nginx
         image: nginx:1.11.13
         ports:
-        - containerPort: 80
+        - name: nginx-port
+          containerPort: 80

--- a/exercises/ex1/nginx-service.yaml
+++ b/exercises/ex1/nginx-service.yaml
@@ -9,4 +9,4 @@ spec:
   ports:
   - protocol: TCP
     port: 80
-    targetPort: 80
+    targetPort: nginx-port

--- a/exercises/ex2/nginx-livenessprobe.yaml
+++ b/exercises/ex2/nginx-livenessprobe.yaml
@@ -1,0 +1,10 @@
+spec:
+  template:
+    spec:
+      containers:
+        - name: nginx
+          livenessProbe:
+            tcpSocket:
+              port: nginx-port
+            initialDelaySeconds: 5
+            periodSeconds: 20

--- a/exercises/ex2/nginx-readinessprobe.yaml
+++ b/exercises/ex2/nginx-readinessprobe.yaml
@@ -1,0 +1,11 @@
+spec:
+  template:
+    spec:
+      containers:
+        - name: nginx
+          readinessProbe:
+            httpGet:
+              path: /
+              port: nginx-port
+            initialDelaySeconds: 3
+            periodSeconds: 3

--- a/exercises/ex2/web-content-pvc.yaml
+++ b/exercises/ex2/web-content-pvc.yaml
@@ -9,4 +9,3 @@ spec:
   resources:
     requests:
       storage: 1Gi
-  storageClassName: glusterfs-storage

--- a/exercises/ex3/README.md
+++ b/exercises/ex3/README.md
@@ -80,7 +80,12 @@ The architecture is the same as it is in exercise 2.
    ```
    You can use the same image as in the previous exercises.
 
-6. As in the previous exercise, copy some content into your site:
+6. If you look at the status of your **Pods** now, you'll see none of them are
+   ready. This is because the site is missing content as was the case in the
+   previous exercise. If you access the URL of the site, you will get an
+   "Application is not available" error from OpenShift.
+
+7. As in the previous exercise, copy some content into your site:
    ```bash
    # Get one of the pods' name
    oc get pods
@@ -88,17 +93,22 @@ The architecture is the same as it is in exercise 2.
    oc rsync ../ex2/html/ <pod name>:/usr/share/nginx/html/
    ```
 
-7. If you access the site now, you should see the same content as in exercise 2.
+8. Get the URL of the site from the **Route**:
+   ```bash
+   oc get routes
+   ```
 
-8. Other things to try:
-   * See how the items created look like in the web UI
-   * Recreate the app from the web interface:
-      * Delete the current project
-      * Create a new project
-      * In the application catalog, select "Import YAML / JSON"
-      * Click "Browse" and select the **Template** file
-      * Click "Create", select "Save template"
-      * Click "Add to Project"
-      * Find your **Template** under "Uncategorized"
-      * Select the "nginx-site" **Template**
-      * Fill in an image and click "Create"
+9. If you access the site now, you should see the same content as in exercise 2.
+
+10. Other things to try:
+    * See how the items created look like in the web UI
+    * Recreate the app from the web interface:
+       * Delete the current project
+       * Create a new project
+       * In the application catalog, select "Import YAML / JSON"
+       * Click "Browse" and select the **Template** file
+       * Click "Create", select "Save template"
+       * Click "Add to Project"
+       * Find your **Template** under "Uncategorized"
+       * Select the "nginx-site" **Template**
+       * Fill in an image and click "Create"

--- a/exercises/ex3/nginx-template.yaml
+++ b/exercises/ex3/nginx-template.yaml
@@ -33,6 +33,15 @@ objects:
           containers:
           - name: nginx
             image: ${NGINX_IMAGE}
+            livenessProbe:
+              tcpSocket:
+                port: nginx-port
+              initialDelaySeconds: 5
+              periodSeconds: 20
+            readinessProbe:
+              httpGet:
+                path: /
+                port: nginx-port
             volumeMounts:
               - mountPath: /usr/share/nginx/html
                 name: web-content-volume
@@ -80,7 +89,7 @@ parameters:
   - name: "NGINX_REPLICAS"
     displayName: "NGINX replica count"
     description: "How many NGINX pods should be created."
-    value: "2"
+    value: "4"
     required: true
   - name: "NGINX_IMAGE"
     displayName: "NGINX image"


### PR DESCRIPTION
- Add liveness and readiness probes to exercise 2.
- Amend the template in exercise 3 to also include the probes.
- Add some clarifications to all three exercises.
- Give a name to the containerPort in the example Deployment so that we
  can refer to the port by name instead of number. This simplifies some
  things that were unnecessarily complicated.
- Remove references to GlusterFS and instead only specify that you need
  a storage type that supports the ReadWriteMany access mode.