### PR TITLE
Add exercises 4 & 5 and a disclaimer to 2&3

### DIFF
--- a/exercises/ex2/README.md
+++ b/exercises/ex2/README.md
@@ -13,6 +13,13 @@ browser.
 
 ## Description
 
+> **Disclaimer:** The method we use to add content to our site in this exercise is
+> not something you should do for a real site. Here we simply do it to
+> demonstrate the usage of volumes and the `oc rsync` command in a way that is
+> hopefully easy to understand if you have some familiarity with web servers.
+> For a real site, you should put the content of your site into the container
+> images as part of your build process.
+
 Now that we have a basic NGINX web server installation, we should look into
 serving some content. We will look at storing data for our website on a
 **PersistentVolume** that we will attach to our **Pods**. Since we will have

--- a/exercises/ex3/README.md
+++ b/exercises/ex3/README.md
@@ -10,6 +10,13 @@ Exercises 0-2 completed.
 
 ## Description
 
+> **Disclaimer:** The method we use to add content to our site in this exercise is
+> not something you should do for a real site. Here we simply do it to
+> demonstrate the usage of volumes and the `oc rsync` command in a way that is
+> hopefully easy to understand if you have some familiarity with web servers.
+> For a real site, you should put the content of your site into the container
+> images as part of your build process.
+
 So far we've been creating API objects individually. These API objects have
 constituted an app when put together. Instead of creating API objects one by
 one, there is another way. You can pack things needed to run an app into an

--- a/exercises/ex4/README.md
+++ b/exercises/ex4/README.md
@@ -1,0 +1,53 @@
+# Exercise 4 - Applying what you've learned so far
+
+## Prerequisites
+
+Completed exercises 0-3.
+
+## Learning objectives
+
+* You are able to apply what you've learned so far about OpenShift to modify
+  an existing site.
+
+## Description
+
+In this exercise the objective is to take the template from exercise 3 and
+modify it so that instead of NGINX, the site is hosted using Apache. You can
+refer to the previous exercises, other course material and the documentation for
+Kubernetes and OpenShift to help you along.
+
+Some hints:
+* The official "httpd" image will try to bind port 80 and thus won't work with
+  OpenShift.
+* There are Apache images maintained in the Docker Hub that do work with
+  OpenShift.
+* The default location where Apache looks for web content is not the same as it
+  was with NGINX - you should take this into account when mounting volumes and
+  copying data into the site.
+
+## Relevant documentation
+
+* [Kubernetes: Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+* [Kubernetes: Persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+* [Kubernetes: Services](https://kubernetes.io/docs/concepts/services-networking/service/)
+* [OpenShift: Routes](https://docs.openshift.org/3.6/architecture/networking/routes.html)
+* [OpenShift: Copying Files to or from a Container](https://docs.openshift.org/latest/dev_guide/copy_files_to_container.html)
+* [OpenShift Origin: Creating New Applications](https://docs.openshift.org/3.6/dev_guide/application_lifecycle/new_app.html)
+
+## Steps
+
+1. You can use an existing project or create a new one. If you decide to use an
+   existing project, make sure you don't try to create any API objects whose
+   name clashes with objects already in the project.
+
+2. Make a copy of the **Template** file from the previous exercise and modify it
+   so that it uses Apache instead of NGINX.
+
+3. Add the newly modified **Template** to OpenShift.
+
+4. Create an Apache site with `oc new-app`.
+
+5. Upload the `index.html` file from exercise 2 to the new site.
+
+6. You should see the same site as before in your browser, but this time served
+   by Apache instead.

--- a/exercises/ex5/README.md
+++ b/exercises/ex5/README.md
@@ -1,0 +1,58 @@
+# Exercise 5 - Build an app from a Dockerfile
+
+## Prerequisites
+
+You have logged into OpenShift with the `oc` tool.
+
+## Learning objectives
+
+* How to take an existing Docker project and run it in OpenShift
+
+## Description
+
+So far we have looked at how to create your own API objects in OpenShift and how
+these API objects can be compiled into a **Template** for a complete site. The
+goal has been to understand some of the building blocks of a site hosted on
+OpenShift. In this exercise we are going to look at how OpenShift can
+automatically generate these building blocks for you based on a Git repository.
+
+## Relevant documentation
+
+* [OpenShift Origin: Creating New Applications](https://docs.openshift.org/3.6/dev_guide/application_lifecycle/new_app.html)
+* [OpenShift Origin: How Builds Work](https://docs.openshift.org/3.6/dev_guide/builds/index.html)
+* [OpenShift Origin: Builds and Image Streams ](https://docs.openshift.com/container-platform/3.6/architecture/core_concepts/builds_and_image_streams.html)
+* [OpenShift Origin: Routes](https://docs.openshift.org/3.6/architecture/networking/routes.html)
+* [Kubernetes: Replication Controller](https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/)
+
+## Steps
+
+1. There is an example application hosted under the Digipalvelutehdas GitHub
+   organisation here:
+   [oso-course-docker-example](https://github.com/Digipalvelutehdas/oso-course-docker-example)
+   Have a look at that repository to see what it contains.
+
+2. Create a new app in OpenShift based on the repository:
+   ```bash
+   oc new-app https://github.com/Digipalvelutehdas/oso-course-docker-example.git
+   ```
+
+3. Have a look at what API objects were automatically created by OpenShift:
+   ```bash
+   oc get all
+   ```
+   Notice that there are some API object types that we haven't covered yet, like
+   a BuildConfig, an ImageStream and a ReplicationController. You can find more
+   about these API object types under the Relevant documentation section.
+
+4. You can get more information about a given API object by specifying
+   `-o yaml`, for example:
+   ```bash
+   oc get dc/oso-course-docker-example -o yaml
+   ```
+
+5. OpenShift has not created a **Route** for you yet, so the application is not
+   yet accesible via a web browser. You can create the **Route** yourself based
+   on the examples in the previous exercises or via the web interface. Once
+   you have done that, you should be able to access the site with its familiar
+   content in your favorite browser. Notice that this time the **Service**
+   exposes port 8080 instead of port 80.


### PR DESCRIPTION
Add exercises 4 and 5 where the knowledge from previous exercises is
applied. In exercise 4, the student must switch from NGINX to Apache as
a web server. In exercise 5, the usage of an existing Dockerfile is
demonstrated for building a site in OpenShift.

Also, since the method we use for adding index.html to the site in
exercises 2 and 3 is not something you would want to do on a real site,
add disclaimers to these exercises explaining this and mention what
users should do instead.