### PR TITLE
Add a top level README.md for exercises

### DIFF
--- a/exercises/README.md
+++ b/exercises/README.md
@@ -1,0 +1,34 @@
+# OpenShift exercises
+
+## Introduction
+
+This directory contains exercises that you can do to learn how to use OpenShift
+via the command line interface.
+
+## Preparations
+
+There are a number of files here that you will need access to while working on
+the exercises. It is easiest to clone this whole repository so that you get all
+the files on your computer before starting to work on the exercises. You can
+find the link to clone this repository on the main page of the repository. Run
+this on the command line to clone the repo:
+
+```bash
+git clone <repo url>
+```
+
+## Instructions
+
+The exercises are meant to be completed in order, though in some cases you may
+skip exercises. Each exercise list prerequisites that you can look at to see if
+you've completed the necessary steps to start the exercise.
+
+Both OpenShift and Kubernetes have good documentation that you can refer to
+while working on the exercises:
+
+  * [Kubernetes documentation](https://kubernetes.io/docs/home/)
+  * [OpenShift documentation](https://docs.openshift.org/latest/welcome/index.html)
+
+Notice that you should refer to the documentation for the correct version of
+Kubernetes/OpenShift. Once you've completed exercise 0, you can get version
+information with the `oc version` command.

--- a/exercises/ex0/README.md
+++ b/exercises/ex0/README.md
@@ -25,7 +25,7 @@ using the `oc` command line tool.
 
 3. If the `oc` tool is not already installed on your computer, you can find a
    link to the releases on the "Command Line Tools" page. Look for 'Download oc'.
-   Install `oc` if needed. It should be a simple binary that you can just 
+   Install `oc` if needed. It should be a simple binary that you can just
    drop in your PATH. To add shell completion support, see `oc completion -h`.
 
 4. Copy the login command from the page and paste it into a terminal. You can
@@ -38,3 +38,16 @@ using the `oc` command line tool.
    ```
    After running this command, later commands will be in the context of the new
    project.
+
+6. Ensure your login session is correct and that you have the correct project
+   selected:
+   ```bash
+   oc status
+   ```
+
+7. Check what version of OpenShift/Kubernetes you are using:
+   ```bash
+   oc version
+   ```
+   This is important so that you know what version's documentation to look at
+   when using OpenShift.


### PR DESCRIPTION
Add an introductory README.md file to read before starting any
exercises. This file instructs you to clone the Git repo first to make
things easier and gives some generic instructions about completing the
exercises.

Also amend exercise 0 based on some of the instructions in the new
README file: add a comment about checking login status and the version
of Kubernetes/OpenShift so that the student knows to use the correct
version of documentation for Kubernetes/OpenShift.